### PR TITLE
fix(Convert-NotesMeetingMembersToMarkdown): Parse emails only properly

### DIFF
--- a/Test/public/convertMeetingMembersToMarkdown.test.ps1
+++ b/Test/public/convertMeetingMembersToMarkdown.test.ps1
@@ -164,7 +164,7 @@ function Test_ConvertMeetingsMembersToMarkdown_Big_sample{
 
     $result = Convert-NotesMeetingMembersToMarkdown -MeetingMembers $imput
 
-    Assert-AreEqual -Presented $result -Expected @"
+    $expected = @"
 - Alphatech (5)
     - "Grace (AlphaTech) Garcia" <grace.garcia@alphatech.com>
     - "Henry Harris" <henry.harris@alphatech.com>
@@ -175,8 +175,8 @@ function Test_ConvertMeetingsMembersToMarkdown_Big_sample{
     - "Amy Adams (She/Her)" <amy.adams@betasoft.com>
     - "Bob Brown" <bob.brown@betasoft.com>
     - "Charlie Chen" <charlie.chen@betasoft.com>
-    - david.davis@betasoft.com
     - "David Dennis" <david.dennis@betasoft.com>
+    - david.davis@betasoft.com
     - emma.edwards@betasoft.com
     - george.garcia@betasoft.com
     - "Iris Ingram" <iris.ingram@betasoft.com>
@@ -192,4 +192,7 @@ function Test_ConvertMeetingsMembersToMarkdown_Big_sample{
     - "Emma Evans, Eric" <emma.evans@deltalab.com>
     - "Frank Fields, Fiona" <frank.fields@deltalab.com>
 "@
+
+    Assert-AreEqual -Presented $result -Expected $expected
+
 }

--- a/Test/public/convertMeetingMembersToMarkdown.test.ps1
+++ b/Test/public/convertMeetingMembersToMarkdown.test.ps1
@@ -116,6 +116,46 @@ function Test_ConvertMeetingMembersToMarkdown_SingleMember {
     Assert-AreEqual -Expected $expected -Presented $result -Comment "Single member should work correctly"
 }
 
+function Test_ConvertMeetingMembersToMarkdown_EmailOnlyFormat {
+
+    # Arrange
+    $input = "john.doe@example.com, jane.smith@example.com, bob@alphatech.com"
+
+    # Act
+    $result = Convert-NotesMeetingMembersToMarkdown -MeetingMembers $input
+
+    # Assert
+    $expected = @"
+- Alphatech (1)
+    - bob@alphatech.com
+- Example (2)
+    - jane.smith@example.com
+    - john.doe@example.com
+"@
+    Assert-AreEqual -Expected $expected -Presented $result -Comment "Email-only format entries should be included and grouped by company"
+}
+
+function Test_ConvertMeetingMembersToMarkdown_MixedEmailFormats {
+
+    # Arrange
+    $input = "Alice Johnson <alice.johnson@alphatech.com>, bob.smith@alphatech.com, `"Charlie Chen`" <charlie.chen@betasoft.com>, david@betasoft.com"
+
+    # Act
+    $result = Convert-NotesMeetingMembersToMarkdown -MeetingMembers $input
+
+    # Assert
+    $expected = @"
+- Alphatech (2)
+    - Alice Johnson <alice.johnson@alphatech.com>
+    - bob.smith@alphatech.com
+- Betasoft (2)
+    - "Charlie Chen" <charlie.chen@betasoft.com>
+    - david@betasoft.com
+"@
+    Assert-AreEqual -Expected $expected -Presented $result -Comment "Mixed email formats should work together, sorted alphabetically by company and member"
+}
+
+
 function Test_ConvertMeetingsMembersToMarkdown_Big_sample{
 
     $imput = @"
@@ -131,16 +171,22 @@ function Test_ConvertMeetingsMembersToMarkdown_Big_sample{
     - "Kevin Kim" <kevin.kim@alphatech.com>
     - "Laura Lewis" <laura.lewis@alphatech.com>
     - "Mark Martinez" <mark.martinez@alphatech.com>
-- Betasoft (9)
+- Betasoft (13)
     - "Amy Adams (She/Her)" <amy.adams@betasoft.com>
     - "Bob Brown" <bob.brown@betasoft.com>
     - "Charlie Chen" <charlie.chen@betasoft.com>
+    - david.davis@betasoft.com
     - "David Dennis" <david.dennis@betasoft.com>
+    - emma.edwards@betasoft.com
+    - george.garcia@betasoft.com
     - "Iris Ingram" <iris.ingram@betasoft.com>
     - "Jack Johnson" <jack.johnson@betasoft.com>
     - "James Jackson" <james.jackson@betasoft.com>
     - "Jennifer Jones" <jennifer.jones@betasoft.com>
     - "Kyle Knight" <kyle.knight@betasoft.com>
+    - lisa.lee@betasoft.com
+- Bookings (1)
+    - george.garcia@bookings.betasoft.com
 - Deltalab (3)
     - "Alice Anderson" <alice.anderson@deltalab.com>
     - "Emma Evans, Eric" <emma.evans@deltalab.com>

--- a/Test/public/getNotes.test.ps1
+++ b/Test/public/getNotes.test.ps1
@@ -14,12 +14,12 @@ function Test_GetNotes_Category{
     Assert-Count -Expected 4 -Presented $result
 
     # Pick a random file to test
-    $file = $result[1]
+    $file = $result[2]
     Assert-AreEqual -Expected "name21-name22-name23.md" -Presented $file.Name
     Assert-AreEqual -Expected "name22" -Presented $file.Category
     Assert-AreEqualPath -Expected $file1 -Presented $file.FullName
 
-    $file = $result[3]
+    $file = $result[0]
     Assert-AreEqual -Expected "name41-name42-name43.md" -Presented $file.Name
     Assert-AreEqual -Expected "name42" -Presented $file.Category
     Assert-AreEqualPath -Expected $file3 -Presented $file.FullName
@@ -48,22 +48,22 @@ function Test_GetNotes_Category_WithDots{
 
     # Pick a random file to test
         # Pick a random file to test
-    $file = $result[1]
+    $file = $result[6]
     Assert-AreEqual -Expected "name11-name12-name13.md" -Presented $file.Name
     Assert-AreEqual -Expected "name12" -Presented $file.Category
     Assert-AreEqualPath -Expected $file1 -Presented $file.FullName
 
-    $file = $result[3]
+    $file = $result[4]
     Assert-AreEqual -Expected "name31-name32-name33.md" -Presented $file.Name
     Assert-AreEqual -Expected "name32" -Presented $file.Category
     Assert-AreEqualPath -Expected $file3 -Presented $file.FullName
 
-    $file = $result[5]
+    $file = $result[2]
     Assert-AreEqual -Expected "name51.name52.name53.md" -Presented $file.Name
     Assert-AreEqual -Expected "name52" -Presented $file.Category
     Assert-AreEqualPath -Expected $file5 -Presented $file.FullName
 
-    $file = $result[7]
+    $file = $result[0]
     Assert-AreEqual -Expected "name71.name72.name73.md" -Presented $file.Name
     Assert-AreEqual -Expected "name72" -Presented $file.Category
     Assert-AreEqualPath -Expected $file7 -Presented $file.FullName

--- a/Test/public/newNotes.test.ps1
+++ b/Test/public/newNotes.test.ps1
@@ -136,7 +136,7 @@ function Test_AddNotesToday_Client_Simple{
     Assert-AreEqual -Expected "Clients" -Presented $greatParent
 }
 
-function Test_NewNotesToday_Failing{
+function Test_NewNotes_SUCCESS{
 
     Reset-InvokeCommandMock
 
@@ -147,11 +147,20 @@ function Test_NewNotesToday_Failing{
     $today = (Get-Date).ToString("yyMMdd")
 
     # Act
-    $result = note howto "someting that may be useful" -NoOpen
+    $result = New-Note howto "someting that may be useful" -NoOpen
+
+    $expectedPath = "./TestNotesRoot/howto/howto-someting_that_may_be_useful/howto-someting_that_may_be_useful.md"
+
+    Assert-AreEqualPath -Expected $expectedPath -Presented $result
+
+    # With date
+
+    $result = New-Note howto "someting that may be useful" -NoOpen -Date $today
 
     $expectedPath = "./TestNotesRoot/howto/$today-howto-someting_that_may_be_useful/$today-howto-someting_that_may_be_useful.md"
 
     Assert-AreEqualPath -Expected $expectedPath -Presented $result
+
 }
 
 # ./TestNotesRoot/howto/250720-howto-someting_that_may_be_useful/250720-howto-someting_that_may_be_useful.md ] 

--- a/private/parseMemberEmail.ps1
+++ b/private/parseMemberEmail.ps1
@@ -45,6 +45,37 @@ function parseMemberEmail {
             }
         }
         
+        # Pattern: just an email address (email@domain.com)
+        $emailPattern = '^([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})$'
+        
+        if ($memberString -match $emailPattern) {
+            $email = $memberString
+            
+            # Extract domain from email
+            $domain = ($email -split '@')[1]
+            if ($domain) {
+                # Get company name from domain (first part before any dots)
+                $company = ($domain -split '\.')[0]
+                # Capitalize first letter if company has content
+                if ($company.Length -gt 0) {
+                    $company = $company.Substring(0, 1).ToUpper() + $company.Substring(1).ToLower()
+                }
+                else {
+                    $company = "Unknown"
+                }
+            }
+            else {
+                $company = "Unknown"
+            }
+
+            return [PSCustomObject]@{
+                DisplayName    = $email
+                Email          = $email
+                Company        = $company
+                OriginalFormat = $memberString
+            }
+        }
+        
         return $null
     }
 }

--- a/private/parseMemberEmail.ps1
+++ b/private/parseMemberEmail.ps1
@@ -103,8 +103,9 @@ function groupMembersByCompany {
         $memberCount = $group.Group.Count
         $result += "- $($group.Name) ($memberCount)"
         
-        # Add members with 4-space indentation
-        foreach ($member in $group.Group) {
+        # Add members with 4-space indentation, sorted case-insensitively by DisplayName (without quotes)
+        $sortedMembers = $group.Group | Sort-Object -Property { ($_.DisplayName.Trim('"')).ToLower() }
+        foreach ($member in $sortedMembers) {
             $result += "    - $($member.OriginalFormat)"
         }
     }

--- a/public/newNotes.ps1
+++ b/public/newNotes.ps1
@@ -30,7 +30,7 @@ function New-Note{
         return
     }
 
-    $fullTitle = getFullTitle $Category $Section $Title $Date
+    $fullTitle = getFullTitle -Category $Category -Section $Section -Title $Title -Date $Date
 
     # Create the note base folder
     if($AvoidChildFolder){
@@ -82,10 +82,10 @@ function New-Note{
 function getFullTitle{
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory,Position=0)][string] $Category,
-        [Parameter(Mandatory,Position=1)][string] $Section,
-        [Parameter(Mandatory,Position=2)][string] $Title,
-        [Parameter(Position=3)][string] $Date
+        [Parameter(Mandatory)][string] $Category,
+        [Parameter(Mandatory)][string] $Title,
+        [Parameter()][string] $Section,
+        [Parameter()][string] $Date
     )
     
     # Create FullTitle using folder name and title, replacing spaces with underscores

--- a/public/notes/templates/none.template.md
+++ b/public/notes/templates/none.template.md
@@ -2,3 +2,6 @@
 
 > {issueurl}
 
+## Notes
+
+{notes}


### PR DESCRIPTION
Enhance email parsing in the Convert-NotesMeetingMembersToMarkdown function to correctly handle various email formats and group members by company. Add tests to ensure proper functionality for both email-only and mixed formats.