### PR TITLE
feat(new-notes): add RootPath parameter to New-Note and related functions

### DIFF
--- a/Test/public/newNotes.test.ps1
+++ b/Test/public/newNotes.test.ps1
@@ -163,6 +163,30 @@ function Test_NewNotes_SUCCESS{
 
 }
 
-# ./TestNotesRoot/howto/250720-howto-someting_that_may_be_useful/250720-howto-someting_that_may_be_useful.md ] 
-# ./TestNotesRoot/howto/250728-howto-someting_that_may_be_useful/250728-howto-someting_that_may_be_useful.md ]
-# [ /tmp/Posh_Testing_250728_87d8dc/TestRunFolder/Test_NewNotesToday_Failing
+function Test_NewNotes_SUCCESS_WithRootPath{
+
+    Reset-InvokeCommandMock
+
+    $RootFolder = "TestNotesRoot"
+
+    New-TestingFolder $RootFolder
+
+    New-TestingFolder -Path "./$RootFolder/howto"
+    $today = (Get-Date).ToString("yyMMdd")
+
+    # Act
+    $result = New-Note howto "someting that may be useful" -NoOpen -RootPath $RootFolder
+
+    $expectedPath = "./$RootFolder/howto/howto-someting_that_may_be_useful/howto-someting_that_may_be_useful.md"
+
+    Assert-AreEqualPath -Expected $expectedPath -Presented $result
+
+    # With date
+
+    $result = New-Note howto "someting that may be useful" -NoOpen -Date $today -RootPath $RootFolder
+
+    $expectedPath = "./$RootFolder/howto/$today-howto-someting_that_may_be_useful/$today-howto-someting_that_may_be_useful.md"
+
+    Assert-AreEqualPath -Expected $expectedPath -Presented $result
+
+}

--- a/private/resolveNotesPath.ps1
+++ b/private/resolveNotesPath.ps1
@@ -24,12 +24,13 @@ function Resolve-NotesPath {
 function Get-NoteFolder{
     [CmdletBinding()]
     param(
+        [Parameter()][string] $RootPath,
         [Parameter()][string] $Category,
         [Parameter()][string] $Section,
         [Parameter()][switch] $Force
     )
     
-    $notesPath = Resolve-NotesPath
+    $notesPath = Resolve-NotesPath -Path $RootPath
 
     # Add the category if needed
     if(-Not [string]::IsNullOrWhiteSpace($Category)) {

--- a/public/newNotes.ps1
+++ b/public/newNotes.ps1
@@ -135,8 +135,8 @@ function New-NoteToday{
     [CmdletBinding()]
     [alias("note")]
     param(
-        [Parameter(Mandatory,Position = 0)][string] $Title,
-        [Parameter()][string] $Category = "Notes",
+        [Parameter(Mandatory,Position = 0)][string] $Category,
+        [Parameter(Mandatory,Position = 1)][string] $Title,
         [Parameter()][string] $Section,
         [Parameter()][string] $Notes,
         [Parameter()][string] $IssueUrl,

--- a/public/newNotes.ps1
+++ b/public/newNotes.ps1
@@ -13,12 +13,14 @@ function New-Note{
         [Parameter()][string] [ValidateSet("none","meetingmini")] $Template = "none",
         [Parameter()][switch] $NoOpen,
         [Parameter()][switch] $AvoidChildFolder,
-        [Parameter()][switch] $Force
+        [Parameter()][switch] $Force,
+        [Parameter()][string] $RootPath
+
     )
 
     # FILENAME
 
-    $folder = Get-NoteFolder -Category $Category -Section $Section -Force:$Force
+    $folder = Get-NoteFolder -RootPath $RootPath -Category $Category -Section $Section -Force:$Force
 
     if(-Not $folder) {
         Write-Error "Failed to create the folder for the note. Try -Force."
@@ -133,20 +135,21 @@ function New-NoteToday{
     [CmdletBinding()]
     [alias("note")]
     param(
-        [Parameter(Mandatory,Position = 0)][string] $Category,
-        [Parameter(Mandatory,Position = 1)][string] $Title,
+        [Parameter(Mandatory,Position = 0)][string] $Title,
+        [Parameter()][string] $Category = "Notes",
         [Parameter()][string] $Section,
         [Parameter()][string] $Notes,
         [Parameter()][string] $IssueUrl,
         [Parameter()][string] [ValidateSet("none","meetingmini")] $Template = "none",
         [Parameter()][switch] $NoOpen,
         [Parameter()][switch] $AvoidChildFolder,
-        [Parameter()][switch] $Force
+        [Parameter()][switch] $Force,
+        [Parameter()][string] $RootPath
     )
 
     # FILENAME
 
-    $folder = Get-NoteFolder -Category $Category -Section $Section -Force:$Force
+    $folder = Get-NoteFolder -RootPath $RootPath -Category $Category -Section $Section -Force:$Force
 
     if(-Not $folder) {
         Write-Error "Failed to create the folder for the note. Try -Force."
@@ -272,7 +275,8 @@ function New-NoteTodayMeeting{
         [Parameter(Position = 2)][string] $Notes,
         [Parameter(ValueFromPipeline)][string] $IssueUrl,
         [Parameter()][switch] $NoOpen,
-        [Parameter()][switch] $Force
+        [Parameter()][switch] $Force,
+        [Parameter()][string] $RootPath
     )
 
     begin {
@@ -282,7 +286,7 @@ function New-NoteTodayMeeting{
 
     process{
 
-        $folder = Get-NoteFolder -Category $category -Section $section -Force:$Force
+        $folder = Get-NoteFolder -RootPath $RootPath -Category $category -Section $section -Force:$Force
 
         if (-not $folder) {
             Write-Error "Client folder for '$section' does not exist and Force was not specified."


### PR DESCRIPTION
Introduce a `RootPath` parameter to the `New-Note` function and related functions to allow users to specify a custom root directory for note creation. This enhancement improves flexibility in organizing notes within different folder structures.