### PR TITLE
fix(New-Note): rename AvoidChildFolder to AddNoteFolder and add DateToday parameter

### DIFF
--- a/Test/public/newNotes.test.ps1
+++ b/Test/public/newNotes.test.ps1
@@ -1,4 +1,4 @@
-function Test_AddNotesToday_Simple{
+function Test_NewNotes_Simple_DateToday{
 
     Reset-InvokeCommandMock
 
@@ -17,15 +17,40 @@ function Test_AddNotesToday_Simple{
     $categoryPath = New-TestingFolder -Path "./TestNotesRoot/$category" -PassThru
 
     # Add note with folder using -Force
-    $path = New-NoteToday $category $title -NoOpen -Force
+    $path = New-Note $category $title -NoOpen -Force -DateToday
 
     $content = Get-Content -Path $path -Raw
 
     Assert-IsTrue $content.StartsWith($header)
 
-    # File should be in a folder of its own name
+    # File should be in the catergory name
     $parentPath = $path | Split-Path -parent
     Assert-AreEqualPath -Expected $categoryPath -Presented $parentPath
+
+}
+
+function Test_NewNote_Simple_WithDate{
+
+    Reset-InvokeCommandMock
+
+    New-TestingFolder "TestNotesRoot"
+    MockCallToString 'Invoke-NotesHelperNotesRoot' -OutString "./TestNotesRoot"
+
+    $category = "TestClient"
+    $title = "This is the title of the note"
+    $date = "240101"
+
+    $header = "# {category} - {title} ({date})"
+    $header = $header -replace "{category}", $category
+    $header = $header -replace "{title}", $title
+    $header = $header -replace "{date}", $date
+
+    # Add note with date
+    $path = New-Note $category $title -NoOpen -Force -Date $date
+
+    $content = Get-Content -Path $path -Raw
+
+    Assert-IsTrue $content.StartsWith($header)
 
 }
 
@@ -42,6 +67,7 @@ function Test_AddNotesToday_Simple_AddNoteFolder {
     New-TestingFolder -Path "./TestNotesRoot/$category"
 
     # Add folder for the note -AddNoteFolder
+    # $path = New-NoteToday $category $title -NoOpen -AddNoteFolder
     $path = New-NoteToday $category $title -NoOpen -AddNoteFolder
 
     # File should be in a folder of its own name
@@ -139,7 +165,8 @@ function Test_NewNotes_SUCCESS{
     # Act
     $result = New-Note howto "someting that may be useful" -NoOpen
 
-    $expectedPath = "./TestNotesRoot/howto/howto-someting_that_may_be_useful/howto-someting_that_may_be_useful.md"
+    # $expectedPath = "./TestNotesRoot/howto/howto-someting_that_may_be_useful/howto-someting_that_may_be_useful.md"
+    $expectedPath = "./TestNotesRoot/howto/howto-someting_that_may_be_useful.md"
 
     Assert-AreEqualPath -Expected $expectedPath -Presented $result
 
@@ -147,7 +174,7 @@ function Test_NewNotes_SUCCESS{
 
     $result = New-Note howto "someting that may be useful" -NoOpen -Date $today
 
-    $expectedPath = "./TestNotesRoot/howto/$today-howto-someting_that_may_be_useful/$today-howto-someting_that_may_be_useful.md"
+    $expectedPath = "./TestNotesRoot/howto/$today-howto-someting_that_may_be_useful.md"
 
     Assert-AreEqualPath -Expected $expectedPath -Presented $result
 
@@ -167,7 +194,8 @@ function Test_NewNotes_SUCCESS_WithRootPath{
     # Act
     $result = New-Note howto "someting that may be useful" -NoOpen -RootPath $RootFolder
 
-    $expectedPath = "./$RootFolder/howto/howto-someting_that_may_be_useful/howto-someting_that_may_be_useful.md"
+    # $expectedPath = "./$RootFolder/howto/howto-someting_that_may_be_useful/howto-someting_that_may_be_useful.md"
+    $expectedPath = "./$RootFolder/howto/howto-someting_that_may_be_useful.md"
 
     Assert-AreEqualPath -Expected $expectedPath -Presented $result
 
@@ -175,7 +203,7 @@ function Test_NewNotes_SUCCESS_WithRootPath{
 
     $result = New-Note howto "someting that may be useful" -NoOpen -Date $today -RootPath $RootFolder
 
-    $expectedPath = "./$RootFolder/howto/$today-howto-someting_that_may_be_useful/$today-howto-someting_that_may_be_useful.md"
+    $expectedPath = "./$RootFolder/howto/$today-howto-someting_that_may_be_useful.md"
 
     Assert-AreEqualPath -Expected $expectedPath -Presented $result
 

--- a/public/newNotes.ps1
+++ b/public/newNotes.ps1
@@ -12,9 +12,10 @@ function New-Note{
         [Parameter()][string] $IssueUrl,
         [Parameter()][string] [ValidateSet("none","meetingmini")] $Template = "none",
         [Parameter()][switch] $NoOpen,
-        [Parameter()][switch] $AvoidChildFolder,
+        [Parameter()][switch] $AddNoteFolder,
         [Parameter()][switch] $Force,
-        [Parameter()][string] $RootPath
+        [Parameter()][string] $RootPath,
+        [Parameter()][switch] $DateToday
 
     )
 
@@ -32,22 +33,27 @@ function New-Note{
         return
     }
 
-    $fullTitle = getFullTitle -Category $Category -Section $Section -Title $Title -Date $Date
+    # Replace date with today if specified
+    if($DateToday) {
+        $Date = Get-Date -Format "yyMMdd"
+    }
+
+    $fileName = getFileName -Category $Category -Section $Section -Title $Title -Date $Date
 
     # Create the note base folder
-    if($AvoidChildFolder){
-        # use folder as the parent folder of the note
-        $fullPath = Join-Path -Path $folder -ChildPath "$fullTitle.md"
-    } else {
+    if($AddNoteFolder){
         # Create full path for the note file
-        $noteFolder = Join-Path -Path $folder -ChildPath $fullTitle
+        $noteFolder = Join-Path -Path $folder -ChildPath $fileName
         
         if (-not (Test-Path -Path $noteFolder)) {
             New-Item -Path $noteFolder -ItemType Directory -Force | Out-Null
             Write-Verbose "Created note folder: $noteFolder"
         }
-
-        $fullPath =$noteFolder | Join-Path -ChildPath "$fullTitle.md"
+        
+        $fullPath =$noteFolder | Join-Path -ChildPath "$fileName.md"
+    } else {
+        # use folder as the parent folder of the note
+        $fullPath = Join-Path -Path $folder -ChildPath "$fileName.md"
     }
     
     # Check if file already exists
@@ -55,7 +61,7 @@ function New-Note{
 
         $header = [string]::IsNullOrWhiteSpace($Section) ? $Category : $Section
 
-        $content = getFileContent $Template $Title $header -Notes $Notes -IssueUrl $IssueUrl
+        $content = getFileContent $Template $Title $header -Notes $Notes -IssueUrl $IssueUrl -Date $Date
 
         # If $Force check that the folders of $fullPath exists and if not create it
         if ($Force) {
@@ -81,7 +87,7 @@ function New-Note{
 
 } Export-ModuleMember -Function New-Note -Alias "note"
 
-function getFullTitle{
+function getFileName{
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string] $Category,
@@ -147,85 +153,120 @@ function New-NoteToday{
         [Parameter()][string] $RootPath
     )
 
-    # FILENAME
+    $ret = New-Note `
+        -Category $Category `
+        -Section $Section `
+        -Title $Title `
+        -Notes $Notes `
+        -IssueUrl $IssueUrl `
+        -Template $Template `
+        -NoOpen:$NoOpen `
+        -AddNoteFolder:$AddNoteFolder `
+        -Force:$Force `
+        -RootPath $RootPath `
+        -DateToday
 
-    $folder = Get-NoteFolder -RootPath $RootPath -Category $Category -Section $Section -Force:$Force
-
-    if(-Not $folder) {
-        Write-Error "Failed to create the folder for the note. Try -Force."
-        return
-    }
-
-    if(-Not (Test-Path -Path $folder)) {
-        Write-Error "Base folder for note does not exist '$folder'. Try -Force."
-        return
-    }
-
-    # Extract just the folder name from the path
-    $today = Get-Date -Format "yyMMdd"
-
-    $header = [string]::IsNullOrWhiteSpace($Section) ? $Category : $Section
-    
-    # Create FullTitle using folder name and title, replacing spaces with underscores
-    $fullTitle = "{0}-{1}-{2}" -f $today, $header, $Title
-
-    # Normilize fullTitle by removing special characters and replacing spaces with underscores
-    $fullTitle = $fullTitle -replace '\s+', '_'
-
-    # Create the note base folder
-
-    if($AddNoteFolder){
-        # Create full path for the note file
-        $noteFolder = Join-Path -Path $folder -ChildPath $fullTitle
-        
-        if (-not (Test-Path -Path $noteFolder)) {
-            New-Item -Path $noteFolder -ItemType Directory -Force | Out-Null
-            Write-Verbose "Created note folder: $noteFolder"
-        }
-
-        $fullPath =$noteFolder | Join-Path -ChildPath "$fullTitle.md"
-    } else {
-            # use folder as the parent folder of the note
-        $fullPath = Join-Path -Path $folder -ChildPath "$fullTitle.md"
-    }
-
-    # Check if file already exists
-    if (-Not (Test-Path -Path $fullPath)) {
-        
-        # Get template content
-        $content = Get-TemplatePath $Template | Get-FileContent
-        
-        # Replace placeholders in the template with actual values
-        $content = $content -replace '{title}'       , $Title
-        $content = $content -replace '{header}'      , $header
-        $content = $content -replace '{date}'        , $today
-        $content = $content -replace '{notes}'       , ([string]::IsNullOrWhiteSpace($Notes)       ? '-' : $Notes)
-        $content = $content -replace '{issueurl}'    , ([string]::IsNullOrWhiteSpace($IssueUrl)    ? '<IssueUrl>' : $IssueUrl)
-
-
-        # If $Force check that the folders of $fullPath exists and if not create it
-        if ($Force) {
-            $parentFolder = Split-Path -Path $fullPath -Parent
-            if (-Not (Test-Path -Path $parentFolder)) {
-                New-Item -Path $parentFolder -ItemType Directory -Force | Out-Null
-                Write-Verbose "Created folder: $parentFolder"
-            }
-        }
-
-        # Create the file with content
-        Set-Content -Path $fullPath -Value $content -Force
-    }
-    
-    if( -not $NoOpen) {
-        # Open file in VS Code with cursor at the end
-        $gotocmd = "{0}{1}" -f $fullPath, ":9999"
-        code --goto $gotocmd 
-    }
-
-    # Return file just created
-    return $fullPath
+    return $ret
 
 } Export-ModuleMember -Function New-NoteToday -Alias "note"
+
+# function New-NoteToday{
+#     # Add Force parameter to support creation of client folder if it doesn't exist
+#     [CmdletBinding()]
+#     [alias("note")]
+#     param(
+#         [Parameter(Mandatory,Position = 0)][string] $Category,
+#         [Parameter(Mandatory,Position = 1)][string] $Title,
+#         [Parameter()][string] $Section,
+#         [Parameter()][string] $Notes,
+#         [Parameter()][string] $IssueUrl,
+#         [Parameter()][string] [ValidateSet("none","meetingmini")] $Template = "none",
+#         [Parameter()][switch] $NoOpen,
+#         [Parameter()][switch] $AddNoteFolder,
+#         [Parameter()][switch] $Force,
+#         [Parameter()][string] $RootPath,
+#         [Parameter()][string] $Date
+#     )
+
+#     # FILENAME
+
+#     $folder = Get-NoteFolder -RootPath $RootPath -Category $Category -Section $Section -Force:$Force
+
+#     if(-Not $folder) {
+#         Write-Error "Failed to create the folder for the note. Try -Force."
+#         return
+#     }
+
+#     if(-Not (Test-Path -Path $folder)) {
+#         Write-Error "Base folder for note does not exist '$folder'. Try -Force."
+#         return
+#     }
+
+#     # Extract just the folder name from the path
+#     $today = if([string]::IsNullOrWhiteSpace($Date)) { Get-Date -Format "yyMMdd" } else { $Date }
+
+#     $header = [string]::IsNullOrWhiteSpace($Section) ? $Category : $Section
+    
+#     # Create FullTitle using folder name and title, replacing spaces with underscores
+#     $fullTitle = "{0}-{1}-{2}" -f $today, $header, $Title
+
+#     # Normilize fullTitle by removing special characters and replacing spaces with underscores
+#     $fullTitle = $fullTitle -replace '\s+', '_'
+
+#     # Create the note base folder
+
+#     if($AddNoteFolder){
+#         # Create full path for the note file
+#         $noteFolder = Join-Path -Path $folder -ChildPath $fullTitle
+        
+#         if (-not (Test-Path -Path $noteFolder)) {
+#             New-Item -Path $noteFolder -ItemType Directory -Force | Out-Null
+#             Write-Verbose "Created note folder: $noteFolder"
+#         }
+
+#         $fullPath =$noteFolder | Join-Path -ChildPath "$fullTitle.md"
+#     } else {
+#             # use folder as the parent folder of the note
+#         $fullPath = Join-Path -Path $folder -ChildPath "$fullTitle.md"
+#     }
+
+#     # Check if file already exists
+#     if (-Not (Test-Path -Path $fullPath)) {
+        
+#         # Get template content
+#         $content = Get-TemplatePath $Template | Get-FileContent
+        
+#         # Replace placeholders in the template with actual values
+#         $content = $content -replace '{title}'       , $Title
+#         $content = $content -replace '{header}'      , $header
+#         $content = $content -replace '{date}'        , $today
+#         $content = $content -replace '{notes}'       , ([string]::IsNullOrWhiteSpace($Notes)       ? '-' : $Notes)
+#         $content = $content -replace '{issueurl}'    , ([string]::IsNullOrWhiteSpace($IssueUrl)    ? '<IssueUrl>' : $IssueUrl)
+
+
+#         # If $Force check that the folders of $fullPath exists and if not create it
+#         if ($Force) {
+#             $parentFolder = Split-Path -Path $fullPath -Parent
+#             if (-Not (Test-Path -Path $parentFolder)) {
+#                 New-Item -Path $parentFolder -ItemType Directory -Force | Out-Null
+#                 Write-Verbose "Created folder: $parentFolder"
+#             }
+#         }
+
+#         # Create the file with content
+#         Set-Content -Path $fullPath -Value $content -Force
+#     }
+    
+#     if( -not $NoOpen) {
+#         # Open file in VS Code with cursor at the end
+#         $gotocmd = "{0}{1}" -f $fullPath, ":9999"
+#         code --goto $gotocmd 
+#     }
+
+#     # Return file just created
+#     return $fullPath
+
+# } Export-ModuleMember -Function New-NoteToday -Alias "note"
 
 function New-NoteTodayClient{
     [CmdletBinding()]


### PR DESCRIPTION
Refactor the `New-Note` function to improve clarity by renaming `AvoidChildFolder` to `AddNoteFolder`. Introduce a new `DateToday` parameter to enhance note creation with date functionality.