### PR TITLE
fix(New-Note): add note creation without date

### DIFF
--- a/Test/public/newNotes.test.ps1
+++ b/Test/public/newNotes.test.ps1
@@ -54,6 +54,29 @@ function Test_NewNote_Simple_WithDate{
 
 }
 
+function Test_NewNote_Simple_WithOutDate{
+
+    Reset-InvokeCommandMock
+
+    New-TestingFolder "TestNotesRoot"
+    MockCallToString 'Invoke-NotesHelperNotesRoot' -OutString "./TestNotesRoot"
+
+    $category = "TestClient"
+    $title = "This is the title of the note"
+
+    $header = "# {category} - {title} (NoDate)"
+    $header = $header -replace "{category}", $category
+    $header = $header -replace "{title}", $title
+
+    # Add note with date
+    $path = New-Note $category $title -NoOpen -Force -Date $date
+
+    $content = Get-Content -Path $path -Raw
+
+    Assert-IsTrue $content.StartsWith($header)
+
+}
+
 function Test_AddNotesToday_Simple_AddNoteFolder {
 
     Reset-InvokeCommandMock

--- a/public/newNotes.ps1
+++ b/public/newNotes.ps1
@@ -129,7 +129,8 @@ function getFileContent{
     # Replace placeholders in the template with actual values
     $content = $content -replace '{title}'       , $Title
     $content = $content -replace '{header}'      , $header
-    $content = $content -replace '{date}'        , $Date
+
+    $content = $content -replace '{date}'        , ([string]::IsNullOrWhiteSpace($Date) ? 'NoDate' : "$Date")
     $content = $content -replace '{notes}'       , ([string]::IsNullOrWhiteSpace($Notes)       ? '-' : $Notes)
     $content = $content -replace '{issueurl}'    , ([string]::IsNullOrWhiteSpace($IssueUrl)    ? '<IssueUrl>' : $IssueUrl)
 


### PR DESCRIPTION
Add a test to verify the creation of notes without a specified date. This ensures that the functionality behaves as expected when the date parameter is omitted.