### PR TITLE
feat(Get-NoteLink): implement function to generate GitHub URL from local file path

### DIFF
--- a/Test/public/getNoteLink.test.ps1
+++ b/Test/public/getNoteLink.test.ps1
@@ -1,0 +1,68 @@
+function Test_GetNoteLink_ReturnsGitHubUrl{
+
+    # Arrange
+    $repoRoot = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent
+    $notePath = Join-Path $repoRoot "public/getnoteLink.ps1"
+
+    # Act
+    $result = Get-NoteLink -NotePath $notePath
+
+    # Assert
+    Assert-IsTrue -Condition ([bool]($result -match "^https://github\.com/.+/blob/.+/public/getnoteLink\.ps1$")) -Comment "Should return a valid GitHub URL"
+}
+
+function Test_GetNoteLink_NestedPath{
+
+    # Arrange
+    $repoRoot = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent
+    $notePath = Join-Path $repoRoot "public/notes/templates/getTemplate.ps1"
+
+    # Act
+    $result = Get-NoteLink -NotePath $notePath
+
+    # Assert
+    Assert-IsTrue -Condition ([bool]($result -match "^https://github\.com/.+/blob/.+/public/notes/templates/getTemplate\.ps1$")) -Comment "Should handle nested paths correctly"
+}
+
+function Test_GetNoteLink_InvalidPath{
+
+    # Arrange
+    $notePath = "/nonexistent/path/file.ps1"
+
+    # Act
+    $result = Get-NoteLink -NotePath $notePath -ErrorAction SilentlyContinue
+
+    # Assert
+    Assert-IsNull -Object $result -Comment "Should return null for invalid path"
+}
+
+function Test_GetNoteLink_NotInGitRepo{
+
+    # Arrange
+    $notePath = "/tmp"
+
+    # Act
+    $result = Get-NoteLink -NotePath $notePath -ErrorAction SilentlyContinue
+
+    # Assert
+    Assert-IsNull -Object $result -Comment "Should return null when path is not in a Git repository"
+}
+
+function Test_GetNoteLink_UsesHostnameFromRemote{
+
+    # Arrange
+    $repoRoot = $PSScriptRoot | Split-Path -Parent | Split-Path -Parent
+    $notePath = Join-Path $repoRoot "README.md"
+    
+    # Get the expected hostname from the actual remote (HTTPS format only)
+    $remoteUrl = git -C $repoRoot remote get-url origin 2>$null
+    if ($remoteUrl -match '^https://([^/]+)/') {
+        $expectedHost = $matches[1]
+    }
+
+    # Act
+    $result = Get-NoteLink -NotePath $notePath
+
+    # Assert
+    Assert-IsTrue -Condition ([bool]($result -match "^https://$expectedHost/")) -Comment "Should use hostname from remote URL"
+}

--- a/Test/public/newNotes.test.ps1
+++ b/Test/public/newNotes.test.ps1
@@ -63,13 +63,15 @@ function Test_NewNote_Simple_WithOutDate{
 
     $category = "TestClient"
     $title = "This is the title of the note"
+    $date = (Get-Date).ToString("yyMMdd")
 
-    $header = "# {category} - {title} (NoDate)"
+    $header = "# {category} - {title} ({date})"
     $header = $header -replace "{category}", $category
     $header = $header -replace "{title}", $title
+    $header = $header -replace "{date}", $date
 
-    # Add note with date
-    $path = New-Note $category $title -NoOpen -Force -Date $date
+    # Add note with DateToday
+    $path = New-Note $category $title -NoOpen -Force -DateToday
 
     $content = Get-Content -Path $path -Raw
 
@@ -185,19 +187,18 @@ function Test_NewNotes_SUCCESS{
     New-TestingFolder -Path "./TestNotesRoot/howto"
     $today = (Get-Date).ToString("yyMMdd")
 
-    # Act
-    $result = New-Note howto "someting that may be useful" -NoOpen
+    # Act - With DateToday
+    $result = New-Note howto "someting that may be useful" -NoOpen -DateToday
 
-    # $expectedPath = "./TestNotesRoot/howto/howto-someting_that_may_be_useful/howto-someting_that_may_be_useful.md"
-    $expectedPath = "./TestNotesRoot/howto/howto-someting_that_may_be_useful.md"
+    $expectedPath = "./TestNotesRoot/howto/$today-howto-someting_that_may_be_useful.md"
 
     Assert-AreEqualPath -Expected $expectedPath -Presented $result
 
-    # With date
+    # With explicit date
 
-    $result = New-Note howto "someting that may be useful" -NoOpen -Date $today
+    $result = New-Note howto "someting that may be useful 2" -NoOpen -Date $today
 
-    $expectedPath = "./TestNotesRoot/howto/$today-howto-someting_that_may_be_useful.md"
+    $expectedPath = "./TestNotesRoot/howto/$today-howto-someting_that_may_be_useful_2.md"
 
     Assert-AreEqualPath -Expected $expectedPath -Presented $result
 
@@ -214,19 +215,18 @@ function Test_NewNotes_SUCCESS_WithRootPath{
     New-TestingFolder -Path "./$RootFolder/howto"
     $today = (Get-Date).ToString("yyMMdd")
 
-    # Act
-    $result = New-Note howto "someting that may be useful" -NoOpen -RootPath $RootFolder
+    # Act - With DateToday
+    $result = New-Note howto "someting that may be useful" -NoOpen -RootPath $RootFolder -DateToday
 
-    # $expectedPath = "./$RootFolder/howto/howto-someting_that_may_be_useful/howto-someting_that_may_be_useful.md"
-    $expectedPath = "./$RootFolder/howto/howto-someting_that_may_be_useful.md"
+    $expectedPath = "./$RootFolder/howto/$today-howto-someting_that_may_be_useful.md"
 
     Assert-AreEqualPath -Expected $expectedPath -Presented $result
 
-    # With date
+    # With explicit date
 
-    $result = New-Note howto "someting that may be useful" -NoOpen -Date $today -RootPath $RootFolder
+    $result = New-Note howto "someting that may be useful 2" -NoOpen -Date $today -RootPath $RootFolder
 
-    $expectedPath = "./$RootFolder/howto/$today-howto-someting_that_may_be_useful.md"
+    $expectedPath = "./$RootFolder/howto/$today-howto-someting_that_may_be_useful_2.md"
 
     Assert-AreEqualPath -Expected $expectedPath -Presented $result
 

--- a/public/getNotes.ps1
+++ b/public/getNotes.ps1
@@ -20,7 +20,7 @@ function Get-Notes () {
     [CmdletBinding()]
     [Alias("notes")]
     param(
-        [Parameter()][string] $Filter,
+        [Parameter(Position=0)][string] $Filter,
         [Parameter()][int32] $DaysAgo,
         #all
         [Parameter()][switch] $All

--- a/public/getnoteLink.ps1
+++ b/public/getnoteLink.ps1
@@ -1,0 +1,58 @@
+function Get-NoteLink {
+    [CmdletBinding()]
+    param (
+        # Local file path to get the GitHub link for
+        [Parameter(Mandatory,ValueFromPipeline,ValueFromPipelineByPropertyName,Position=0)][Alias("Path")][string] $NotePath
+    )
+
+    # Resolve the full path
+    $fullPath = Resolve-Path -Path $NotePath -ErrorAction SilentlyContinue
+    if (-not $fullPath) {
+        Write-Error "Path not found: $NotePath"
+        return
+    }
+
+    # Get the directory to run git commands from
+    $workingDir = if (Test-Path -Path $fullPath -PathType Container) { $fullPath } else { Split-Path -Path $fullPath -Parent }
+
+    # Get the git root directory
+    $gitRoot = git -C $workingDir rev-parse --show-toplevel 2>$null
+    if (-not $gitRoot) {
+        Write-Error "Path is not inside a Git repository: $NotePath"
+        return
+    }
+
+    # Get the remote origin URL
+    $remoteUrl = git -C $gitRoot remote get-url origin 2>$null
+    if (-not $remoteUrl) {
+        Write-Error "No remote 'origin' found for repository"
+        return
+    }
+
+    # Parse HTTPS URL format
+    # HTTPS format: https://hostname/owner/repo.git
+    if ($remoteUrl -match '^https://([^/]+)/(.+?)(?:\.git)?$') {
+        $hostName = $matches[1]
+        $repoPath = $matches[2] -replace '\.git$', ''
+        $baseUrl = "https://$hostName/$repoPath"
+    }
+    else {
+        Write-Error "Unsupported remote URL format: $remoteUrl"
+        return
+    }
+
+    # Get the current branch
+    $branch = git -C $gitRoot rev-parse --abbrev-ref HEAD 2>$null
+    if (-not $branch) {
+        $branch = "main"
+    }
+
+    # Get the relative path from the git root
+    $relativePath = $fullPath.Path.Substring($gitRoot.Length).TrimStart('/', '\') -replace '\\', '/'
+
+    # Construct the GitHub URL
+    $githubUrl = "$baseUrl/blob/$branch/$relativePath"
+
+    return $githubUrl
+} Export-ModuleMember -Function Get-NoteLink
+


### PR DESCRIPTION
Introduce a new function to generate a GitHub URL from a local file path, enhancing the ability to link notes directly to their repository locations. Adjusted the parameter position for the existing Get-Notes function to improve usability.