### PR TITLE
Fix email grouping to use registered domain instead of first subdomain

### DIFF
--- a/Test/public/convertMeetingMembersToMarkdown.test.ps1
+++ b/Test/public/convertMeetingMembersToMarkdown.test.ps1
@@ -248,7 +248,7 @@ function Test_ConvertMeetingsMembersToMarkdown_Big_sample{
     - "Kevin Kim" <kevin.kim@alphatech.com>
     - "Laura Lewis" <laura.lewis@alphatech.com>
     - "Mark Martinez" <mark.martinez@alphatech.com>
-- Betasoft (13)
+- Betasoft (14)
     - "Amy Adams (She/Her)" <amy.adams@betasoft.com>
     - "Bob Brown" <bob.brown@betasoft.com>
     - "Charlie Chen" <charlie.chen@betasoft.com>
@@ -256,14 +256,13 @@ function Test_ConvertMeetingsMembersToMarkdown_Big_sample{
     - david.davis@betasoft.com
     - emma.edwards@betasoft.com
     - george.garcia@betasoft.com
+    - george.garcia@bookings.betasoft.com
     - "Iris Ingram" <iris.ingram@betasoft.com>
     - "Jack Johnson" <jack.johnson@betasoft.com>
     - "James Jackson" <james.jackson@betasoft.com>
     - "Jennifer Jones" <jennifer.jones@betasoft.com>
     - "Kyle Knight" <kyle.knight@betasoft.com>
     - lisa.lee@betasoft.com
-- Bookings (1)
-    - george.garcia@bookings.betasoft.com
 - Deltalab (3)
     - "Alice Anderson" <alice.anderson@deltalab.com>
     - "Emma Evans, Eric" <emma.evans@deltalab.com>
@@ -272,4 +271,21 @@ function Test_ConvertMeetingsMembersToMarkdown_Big_sample{
 
     Assert-AreEqual -Presented $result -Expected $expected
 
+}
+
+function Test_ConvertMeetingMembersToMarkdown_SubdomainEmailGroupsByRegisteredDomain {
+
+    # Arrange
+    $input = "Alice Johnson <alice.johnson@emea.contoso.com>, Bob Smith <bob.smith@contoso.com>"
+
+    # Act
+    $result = Convert-NotesMeetingMembersToMarkdown -MeetingMembers $input
+
+    # Assert
+    $expected = @"
+- Contoso (2)
+    - Alice Johnson <alice.johnson@emea.contoso.com>
+    - Bob Smith <bob.smith@contoso.com>
+"@
+    Assert-AreEqual -Expected $expected -Presented $result -Comment "Subdomain like emea.contoso.com should group under the registered domain (contoso), not the subdomain"
 }

--- a/private/parseMemberEmail.ps1
+++ b/private/parseMemberEmail.ps1
@@ -28,8 +28,8 @@ function parseMemberEmail {
             # Extract domain from email
             $domain = ($email -split '@')[1]
             if ($domain) {
-                # Get company name from domain (first part before any dots)
-                $company = ($domain -split '\.')[0]
+                # Get company name from domain (second-to-last segment, i.e. registered domain before TLD)
+                $company = ($domain -split '\.')[-2]
                 # Capitalize first letter if company has content
                 if ($company.Length -gt 0) {
                     $company = $company.Substring(0, 1).ToUpper() + $company.Substring(1).ToLower()
@@ -77,8 +77,8 @@ function parseMemberEmail {
             # Extract domain from email
             $domain = ($email -split '@')[1]
             if ($domain) {
-                # Get company name from domain (first part before any dots)
-                $company = ($domain -split '\.')[0]
+                # Get company name from domain (second-to-last segment, i.e. registered domain before TLD)
+                $company = ($domain -split '\.')[-2]
                 # Capitalize first letter if company has content
                 if ($company.Length -gt 0) {
                     $company = $company.Substring(0, 1).ToUpper() + $company.Substring(1).ToLower()


### PR DESCRIPTION
## Why

When grouping meeting members by company, the code was extracting the company name from the **first** segment of the email domain. This caused `me@emea.contoso.com` to be grouped under "Emea" instead of the correct "Contoso" -- a regional subdomain was being mistaken for the company identity.

## What changed

The company name is now extracted from the **second-to-last** segment of the domain (the registered domain name, immediately before the TLD), which correctly reflects the user's organizational identity regardless of any subdomain prefix.

- `me@emea.contoso.com` -> **Contoso**
- `user@us.acme.org` -> **Acme**
- `alice@alphatech.com` -> **Alphatech** (unchanged for simple domains)

The fix is applied in both email-parsing code paths inside `parseMemberEmail` (named format and plain email format).

## Tests

- Updated `Test_ConvertMeetingsMembersToMarkdown_Big_sample`: `george.garcia@bookings.betasoft.com` now groups under **Betasoft** (14 members) instead of the separate **Bookings** group, consistent with the new logic.
- Added `Test_ConvertMeetingMembersToMarkdown_SubdomainEmailGroupsByRegisteredDomain`: verifies that `emea.contoso.com` and `contoso.com` both group under **Contoso**.

All 41 tests pass.